### PR TITLE
Fix for https://github.com/opentk/ObjectTK/issues/6

### DIFF
--- a/ObjectTK/Shaders/ProgramFactory.cs
+++ b/ObjectTK/Shaders/ProgramFactory.cs
@@ -133,10 +133,11 @@ namespace ObjectTK.Shaders
                     if (line == null) break;
                     // check if it is an include statement
                     const string includeKeyword = "#include";
+                    const string versionKeyword = "#version";
                     if (!line.StartsWith(includeKeyword))
                     {
                         // add correct line number offset to the corresponding section within the effect file
-                        if (fixLine)
+                        if ((fixLine)&& !line.StartsWith(versionKeyword) )
                         {
                             source.AppendLine(string.Format("#line {0} {1}", lineNumber, fileNumber));
                             fixLine = false;


### PR DESCRIPTION
Delivered fix of compilation generated shader files. 

Lines with `#version` directive will not have numbers by them