### PR TITLE
Make log4net library optional

### DIFF
--- a/Examples/ExampleBrowserEntry.cs
+++ b/Examples/ExampleBrowserEntry.cs
@@ -9,13 +9,20 @@ namespace Examples
         [STAThread]
         public static void Main()
         {
-            // initialize log4net via app.config
-            XmlConfigurator.Configure();
+            // initialize log4net via app.config if available
+            if (ObjectTK.Logging.LogFactory.IsAvailable)
+                ConfigureLogging();
+
             // show example browser
             using (var browser = new ExampleBrowser())
             {
                 Application.Run(browser);
             }
+        }
+
+        public static void ConfigureLogging()
+        {
+            XmlConfigurator.Configure();
         }
     }
 }

--- a/ObjectTK.Tools/DerpWindow.cs
+++ b/ObjectTK.Tools/DerpWindow.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using log4net;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
@@ -22,7 +21,7 @@ namespace ObjectTK.Tools
     public abstract class DerpWindow
         : GameWindow
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(DerpWindow));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(DerpWindow));
 
         protected readonly FrameTimer FrameTimer;
 
@@ -33,16 +32,16 @@ namespace ObjectTK.Tools
             : base(width, height, mode, title)
         {
             // log some OpenGL information
-            Logger.Info("OpenGL context information:");
-            Logger.InfoFormat("{0}: {1}", StringName.Vendor, GL.GetString(StringName.Vendor));
-            Logger.InfoFormat("{0}: {1}", StringName.Renderer, GL.GetString(StringName.Renderer));
-            Logger.InfoFormat("{0}: {1}", StringName.Version, GL.GetString(StringName.Version));
-            Logger.InfoFormat("{0}: {1}", StringName.ShadingLanguageVersion, GL.GetString(StringName.ShadingLanguageVersion));
+            Logger?.Info("OpenGL context information:");
+            Logger?.InfoFormat("{0}: {1}", StringName.Vendor, GL.GetString(StringName.Vendor));
+            Logger?.InfoFormat("{0}: {1}", StringName.Renderer, GL.GetString(StringName.Renderer));
+            Logger?.InfoFormat("{0}: {1}", StringName.Version, GL.GetString(StringName.Version));
+            Logger?.InfoFormat("{0}: {1}", StringName.ShadingLanguageVersion, GL.GetString(StringName.ShadingLanguageVersion));
             int numExtensions;
             GL.GetInteger(GetPName.NumExtensions, out numExtensions);
-            Logger.DebugFormat("Number available extensions: {0}", numExtensions);
-            for (var i = 0; i < numExtensions; i++) Logger.DebugFormat("{0}: {1}", i, GL.GetString(StringNameIndexed.Extensions, i));
-            Logger.InfoFormat("Initializing game window: {0}", title);
+            Logger?.DebugFormat("Number available extensions: {0}", numExtensions);
+            for (var i = 0; i < numExtensions; i++) Logger?.DebugFormat("{0}: {1}", i, GL.GetString(StringNameIndexed.Extensions, i));
+            Logger?.InfoFormat("Initializing game window: {0}", title);
             // set up GameWindow events
             Resize += OnResize;
             UpdateFrame += OnUpdateFrame;
@@ -52,7 +51,7 @@ namespace ObjectTK.Tools
 
         private void OnResize(object sender, EventArgs eventArgs)
         {
-            Logger.InfoFormat("Window resized to: {0}x{1}", Width, Height);
+            Logger?.InfoFormat("Window resized to: {0}x{1}", Width, Height);
         }
 
         private void OnUpdateFrame(object sender, FrameEventArgs e)

--- a/ObjectTK.Tools/ObjectTK.Tools.csproj
+++ b/ObjectTK.Tools/ObjectTK.Tools.csproj
@@ -65,10 +65,6 @@
     <Compile Include="Shapes\TexturedShape.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\OpenTK.1.1.1589.5942\lib\NET40\OpenTK.dll</HintPath>

--- a/ObjectTK.Tools/packages.config
+++ b/ObjectTK.Tools/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net40" />
   <package id="OpenTK" version="1.1.1589.5942" targetFramework="net40" />
 </packages>

--- a/ObjectTK/GLResource.cs
+++ b/ObjectTK/GLResource.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Reflection;
-using log4net;
 using ObjectTK.Exceptions;
 
 namespace ObjectTK
@@ -22,7 +21,7 @@ namespace ObjectTK
     public abstract class GLResource
         : IDisposable
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(GLResource));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(GLResource));
 
         /// <summary>
         /// Gets a values specifying if this resource has already been disposed.
@@ -42,7 +41,7 @@ namespace ObjectTK
         /// </summary>
         ~GLResource()
         {
-            Logger.WarnFormat("GLResource leaked: {0}", this);
+            Logger?.WarnFormat("GLResource leaked: {0}", this);
             Dispose(false);
 #if DEBUG
             throw new ObjectTKException(string.Format("GLResource leaked: {0}", this));

--- a/ObjectTK/Logging/DefaultLogImpl.cs
+++ b/ObjectTK/Logging/DefaultLogImpl.cs
@@ -1,0 +1,135 @@
+﻿//
+// DefaultLogImpl.cs
+//
+// Copyright (C) 2018 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+
+using System;
+using log4net;
+using log4net.Core;
+
+namespace ObjectTK.Logging
+{
+    public class DefaultLogImpl : IObjectTKLogger
+    {
+        protected virtual Type ThisDeclaringType => typeof(DefaultLogImpl);
+        protected ILogger _logger => _log.Logger;
+
+        protected readonly ILog _log;
+
+        public DefaultLogImpl(ILog logger)
+        {
+            _log = logger;
+        }
+
+        public bool IsFatalEnabled => _log.IsFatalEnabled;
+
+        public bool IsWarnEnabled => _log.IsWarnEnabled;
+
+        public bool IsInfoEnabled => _log.IsInfoEnabled;
+
+        public bool IsDebugEnabled => _log.IsDebugEnabled;
+
+        public bool IsErrorEnabled => _log.IsErrorEnabled;
+
+        private void Log(Level level, object message, Exception exception = null)
+        {
+            if (!_logger.IsEnabledFor(level)) return;
+            _logger.Log(ThisDeclaringType, level, message, exception);
+        }
+
+        private void LogFormat(Level level, IFormatProvider provider, string format, params object[] args)
+        {
+            if (!_logger.IsEnabledFor(level)) return;
+
+            var message = (provider == null) ?
+                string.Format(format, args) :
+                string.Format(provider, format, args);
+
+            _logger.Log(ThisDeclaringType, level, message, null);
+        }
+
+        private void LogFormat(Level level, string format, params object[] args)
+        {
+            LogFormat(null, format, args);
+        }
+
+        public void Debug(object message, Exception exception = null)
+        {
+            Log(Level.Debug, message);
+        }
+
+        public void DebugFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            LogFormat(Level.Debug, provider, format, args);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            LogFormat(Level.Debug, null, format, args);
+        }
+
+        public void Error(object message, Exception exception = null)
+        {
+            Log(Level.Error, message);
+        }
+
+        public void ErrorFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            LogFormat(Level.Error, provider, format, args);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            LogFormat(Level.Error, null, format, args);
+        }
+
+        public void Fatal(object message, Exception exception = null)
+        {
+            Log(Level.Fatal, message);
+        }
+
+        public void FatalFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            LogFormat(Level.Fatal, provider, format, args);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            LogFormat(Level.Fatal, null, format, args);
+        }
+
+        public void Info(object message, Exception exception = null)
+        {
+            Log(Level.Info, message);
+        }
+
+        public void InfoFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            LogFormat(Level.Info, provider, format, args);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            LogFormat(Level.Info, null, format, args);
+        }
+
+        public void Warn(object message, Exception exception = null)
+        {
+            Log(Level.Warn, message);
+        }
+
+        public void WarnFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            LogFormat(Level.Warn, provider, format, args);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            LogFormat(Level.Warn, null, format, args);
+        }
+    }
+}

--- a/ObjectTK/Logging/IObjectTKLogger.cs
+++ b/ObjectTK/Logging/IObjectTKLogger.cs
@@ -1,0 +1,45 @@
+﻿//
+// IObjectTKLogger.cs
+//
+// Copyright (C) 2018 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ObjectTK.Logging
+{
+    public interface IObjectTKLogger
+    {
+        bool IsFatalEnabled { get; }
+        bool IsWarnEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsDebugEnabled { get; }
+        bool IsErrorEnabled { get; }
+
+        void Debug(object message, Exception exception = null);
+        void DebugFormat(IFormatProvider provider, string format, params object[] args);
+        void DebugFormat(string format, params object[] args);
+
+        void Error(object message, Exception exception = null);
+        void ErrorFormat(IFormatProvider provider, string format, params object[] args);
+        void ErrorFormat(string format, params object[] args);
+
+        void Fatal(object message, Exception exception = null);
+        void FatalFormat(IFormatProvider provider, string format, params object[] args);
+        void FatalFormat(string format, params object[] args);
+
+        void Info(object message, Exception exception = null);
+        void InfoFormat(IFormatProvider provider, string format, params object[] args);
+        void InfoFormat(string format, params object[] args);
+
+        void Warn(object message, Exception exception = null);
+        void WarnFormat(IFormatProvider provider, string format, params object[] args);
+        void WarnFormat(string format, params object[] args);
+    }
+}

--- a/ObjectTK/Logging/LogFactory.cs
+++ b/ObjectTK/Logging/LogFactory.cs
@@ -1,0 +1,31 @@
+﻿//
+// LogFactory.cs
+//
+// Copyright (C) 2018 OpenTK
+//
+// This software may be modified and distributed under the terms
+// of the MIT license. See the LICENSE file for details.
+//
+
+using System;
+using System.IO;
+using log4net;
+
+namespace ObjectTK.Logging
+{
+    public static class LogFactory
+    {
+        public static readonly bool IsAvailable = File.Exists(AppDomain.CurrentDomain.BaseDirectory + "log4net.dll");
+
+        static IObjectTKLogger CreateLogger(Type type)
+        {
+            var logger = LogManager.GetLogger(type);
+            return logger != null ? new DefaultLogImpl(logger) : null;
+        }
+
+        public static IObjectTKLogger GetLogger(Type type)
+        {
+            return IsAvailable ? CreateLogger(type) : null;
+        }
+    }
+}

--- a/ObjectTK/ObjectTK.csproj
+++ b/ObjectTK/ObjectTK.csproj
@@ -62,6 +62,9 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="GLObject.cs" />
     <Compile Include="GLResource.cs" />
+    <Compile Include="Logging\DefaultLogImpl.cs" />
+    <Compile Include="Logging\IObjectTKLogger.cs" />
+    <Compile Include="Logging\LogFactory.cs" />
     <Compile Include="MathF.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Queries\QueryIndexer.cs" />

--- a/ObjectTK/Shaders/Effect.cs
+++ b/ObjectTK/Shaders/Effect.cs
@@ -10,7 +10,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using log4net;
 
 namespace ObjectTK.Shaders
 {
@@ -20,7 +19,7 @@ namespace ObjectTK.Shaders
     /// </summary>
     public class Effect
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(Effect));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(Effect));
 
         private static readonly Dictionary<string, Effect> Cache = new Dictionary<string, Effect>();
 
@@ -149,7 +148,7 @@ namespace ObjectTK.Shaders
             }
             catch (FileNotFoundException ex)
             {
-                Logger.Error("Effect source file not found.", ex);
+                Logger?.Error("Effect source file not found.", ex);
                 throw;
             }
         }

--- a/ObjectTK/Shaders/Program.cs
+++ b/ObjectTK/Shaders/Program.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using log4net;
 using ObjectTK.Exceptions;
 using ObjectTK.Shaders.Variables;
 using OpenTK.Graphics.OpenGL;
@@ -24,7 +23,7 @@ namespace ObjectTK.Shaders
     public class Program
         : GLObject
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(Program));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(Program));
 
         /// <summary>
         /// The name of this shader program.
@@ -39,7 +38,7 @@ namespace ObjectTK.Shaders
         protected Program()
             : base(GL.CreateProgram())
         {
-            Logger.InfoFormat("Creating shader program: {0}", Name);
+            Logger?.InfoFormat("Creating shader program: {0}", Name);
             InitializeShaderVariables();
         }
 
@@ -93,7 +92,7 @@ namespace ObjectTK.Shaders
         /// </summary>
         public virtual void Link()
         {
-            Logger.DebugFormat("Linking program: {0}", Name);
+            Logger?.DebugFormat("Linking program: {0}", Name);
             GL.LinkProgram(Handle);
             CheckLinkStatus();
             // call OnLink() on all ShaderVariables
@@ -108,14 +107,14 @@ namespace ObjectTK.Shaders
             // check link status
             int linkStatus;
             GL.GetProgram(Handle, GetProgramParameterName.LinkStatus, out linkStatus);
-            Logger.DebugFormat("Link status: {0}", linkStatus);
+            Logger?.DebugFormat("Link status: {0}", linkStatus);
             // check program info log
             var info = GL.GetProgramInfoLog(Handle);
-            if (!string.IsNullOrEmpty(info)) Logger.InfoFormat("Link log:\n{0}", info);
+            if (!string.IsNullOrEmpty(info)) Logger?.InfoFormat("Link log:\n{0}", info);
             // log message and throw exception on link error
             if (linkStatus == 1) return;
             var msg = string.Format("Error linking program: {0}", Name);
-            Logger.Error(msg);
+            Logger?.Error(msg);
             throw new ProgramLinkException(msg, info);
         }
 

--- a/ObjectTK/Shaders/ProgramFactory.cs
+++ b/ObjectTK/Shaders/ProgramFactory.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using log4net;
 using ObjectTK.Exceptions;
 using ObjectTK.Shaders.Sources;
 
@@ -23,7 +22,7 @@ namespace ObjectTK.Shaders
     /// </summary>
     public static class ProgramFactory
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(ProgramFactory));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(ProgramFactory));
 
         /// <summary>
         /// The base path used when looking for shader files.<br/>
@@ -64,7 +63,7 @@ namespace ObjectTK.Shaders
                     // create a new shader of the appropriate type
                     using (var shader = new Shader(attribute.Type))
                     {
-                        Logger.DebugFormat("Compiling {0}: {1}", attribute.Type, attribute.EffectKey);
+                        Logger?.DebugFormat("Compiling {0}: {1}", attribute.Type, attribute.EffectKey);
                         // load the source from effect(s)
                         var included = new List<Effect.Section>();
                         var source = GetShaderSource(attribute.EffectKey, included);
@@ -116,7 +115,7 @@ namespace ObjectTK.Shaders
             // check for multiple includes of the same section
             if (included.Contains(section))
             {
-                Logger.WarnFormat("Shader already included: {0}", effectKey);
+                Logger?.WarnFormat("Shader already included: {0}", effectKey);
                 return "";
             }
             included.Add(section);

--- a/ObjectTK/Shaders/Shader.cs
+++ b/ObjectTK/Shaders/Shader.cs
@@ -9,7 +9,6 @@
 
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using log4net;
 using ObjectTK.Exceptions;
 using OpenTK.Graphics.OpenGL;
 
@@ -21,7 +20,7 @@ namespace ObjectTK.Shaders
     public class Shader
         : GLObject
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(Shader));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(Shader));
 
         /// <summary>
         /// Specifies the type of this shader.
@@ -72,15 +71,15 @@ namespace ObjectTK.Shaders
             // check compile status
             int compileStatus;
             GL.GetShader(Handle, ShaderParameter.CompileStatus, out compileStatus);
-            Logger.DebugFormat("Compile status: {0}", compileStatus);
+            Logger?.DebugFormat("Compile status: {0}", compileStatus);
             // check shader info log
             var info = GL.GetShaderInfoLog(Handle);
             if (SourceFiles != null) info = Regenechse.Replace(info, GetSource);
-            if (!string.IsNullOrEmpty(info)) Logger.InfoFormat("Compile log:\n{0}", info);
+            if (!string.IsNullOrEmpty(info)) Logger?.InfoFormat("Compile log:\n{0}", info);
             // log message and throw exception on compile error
             if (compileStatus == 1) return;
             const string msg = "Error compiling shader.";
-            Logger.Error(msg);
+            Logger?.Error(msg);
             throw new ShaderCompileException(msg, info);
         }
 

--- a/ObjectTK/Shaders/Variables/BufferBinding.cs
+++ b/ObjectTK/Shaders/Variables/BufferBinding.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using log4net;
 using ObjectTK.Buffers;
 using OpenTK.Graphics.OpenGL;
 
@@ -20,7 +19,7 @@ namespace ObjectTK.Shaders.Variables
     public abstract class BufferBinding
         : ProgramVariable
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(BufferBinding));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(BufferBinding));
 
         /// <summary>
         /// The target to use when binding to this point.
@@ -49,7 +48,7 @@ namespace ObjectTK.Shaders.Variables
         {
             Index = GL.GetProgramResourceIndex(ProgramHandle, _programInterface, Name);
             Active = Index > -1;
-            if (!Active) Logger.WarnFormat("Binding block not found or not active: {0}", Name);
+            if (!Active) Logger?.WarnFormat("Binding block not found or not active: {0}", Name);
             Binding = -1;
         }
 

--- a/ObjectTK/Shaders/Variables/FragData.cs
+++ b/ObjectTK/Shaders/Variables/FragData.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using log4net;
 using OpenTK.Graphics.OpenGL;
 
 namespace ObjectTK.Shaders.Variables
@@ -20,7 +19,7 @@ namespace ObjectTK.Shaders.Variables
     public sealed class FragData
         : ProgramVariable
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(FragData));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(FragData));
 
         /// <summary>
         /// The location of the output.
@@ -35,7 +34,7 @@ namespace ObjectTK.Shaders.Variables
         {
             //TODO: find out what GL.GetFragDataIndex(); does
             Location = GL.GetFragDataLocation(ProgramHandle, Name);
-            if (Location == -1) Logger.WarnFormat("Output variable not found or not active: {0}", Name);
+            if (Location == -1) Logger?.WarnFormat("Output variable not found or not active: {0}", Name);
         }
     }
 }

--- a/ObjectTK/Shaders/Variables/Uniform.cs
+++ b/ObjectTK/Shaders/Variables/Uniform.cs
@@ -8,7 +8,6 @@
 //
 
 using System;
-using log4net;
 using OpenTK.Graphics.OpenGL;
 
 namespace ObjectTK.Shaders.Variables
@@ -20,7 +19,7 @@ namespace ObjectTK.Shaders.Variables
     public class Uniform<T>
         : ProgramVariable
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(Uniform<T>));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(Uniform<T>));
 
         /// <summary>
         /// The location of the uniform within the shader program.
@@ -68,7 +67,7 @@ namespace ObjectTK.Shaders.Variables
         {
             Location = GL.GetUniformLocation(ProgramHandle, Name);
             Active = Location > -1;
-            if (!Active) Logger.WarnFormat("Uniform not found or not active: {0}", Name);
+            if (!Active) Logger?.WarnFormat("Uniform not found or not active: {0}", Name);
         }
 
         /// <summary>

--- a/ObjectTK/Shaders/Variables/VertexAttrib.cs
+++ b/ObjectTK/Shaders/Variables/VertexAttrib.cs
@@ -9,7 +9,6 @@
 
 using System.Linq;
 using System.Reflection;
-using log4net;
 using OpenTK.Graphics.OpenGL;
 
 namespace ObjectTK.Shaders.Variables
@@ -20,7 +19,7 @@ namespace ObjectTK.Shaders.Variables
     public sealed class VertexAttrib
         : ProgramVariable
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(VertexAttrib));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(VertexAttrib));
 
         /// <summary>
         /// The vertex attributes location within the shader.
@@ -66,7 +65,7 @@ namespace ObjectTK.Shaders.Variables
         {
             Index = GL.GetAttribLocation(ProgramHandle, Name);
             Active = Index > -1;
-            if (!Active) Logger.WarnFormat("Vertex attribute not found or not active: {0}", Name);
+            if (!Active) Logger?.WarnFormat("Vertex attribute not found or not active: {0}", Name);
         }
     }
 }

--- a/ObjectTK/Utility.cs
+++ b/ObjectTK/Utility.cs
@@ -7,7 +7,6 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using log4net;
 using ObjectTK.Exceptions;
 using OpenTK.Graphics.OpenGL;
 
@@ -15,7 +14,7 @@ namespace ObjectTK
 {
     internal static class Utility
     {
-        private static readonly ILog Logger = LogManager.GetLogger(typeof(Utility));
+        private static readonly Logging.IObjectTKLogger Logger = Logging.LogFactory.GetLogger(typeof(Utility));
 
         public static void Assert(string errorMessage)
         {
@@ -30,7 +29,7 @@ namespace ObjectTK
         public static void Assert<T>(T value, T desiredValue, string errorMessage)
         {
             if (desiredValue.Equals(value)) return;
-            Logger.Error(string.Format("Assert failed: {0}\n{1}", value, errorMessage));
+            Logger?.Error(string.Format("Assert failed: {0}\n{1}", value, errorMessage));
             throw new ObjectTKException(string.Format("ErrorCode: {0}\n{1}", value, errorMessage));
         }
     }


### PR DESCRIPTION
Introduces an abstraction layer for the log4net library, so it doesn't necessarily must be shipped with the application.
If log4net.dll is not present in the applications folder logging will be disabled implictly.